### PR TITLE
Tell the JVM to be aware of Docker memory limits

### DIFF
--- a/3.9.2/arabic/Dockerfile
+++ b/3.9.2/arabic/Dockerfile
@@ -30,4 +30,4 @@ ENV LOGIN ""
 ENV PASSWORD ""
 EXPOSE $PORT
 
-CMD if [ $LOGIN = "" ]; then java -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT ; else java -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT -username $LOGIN -password $PASSWORD ; fi 
+CMD if [ $LOGIN = "" ]; then java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT ; else java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT -username $LOGIN -password $PASSWORD ; fi

--- a/3.9.2/chinese/Dockerfile
+++ b/3.9.2/chinese/Dockerfile
@@ -30,4 +30,4 @@ ENV LOGIN ""
 ENV PASSWORD ""
 EXPOSE $PORT
 
-CMD if [ $LOGIN = "" ]; then java -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT ; else java -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT -username $LOGIN -password $PASSWORD ; fi 
+CMD if [ $LOGIN = "" ]; then java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT ; else java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT -username $LOGIN -password $PASSWORD ; fi

--- a/3.9.2/english-kbp/Dockerfile
+++ b/3.9.2/english-kbp/Dockerfile
@@ -30,4 +30,4 @@ ENV LOGIN ""
 ENV PASSWORD ""
 EXPOSE $PORT
 
-CMD if [ $LOGIN = "" ]; then java -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT ; else java -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT -username $LOGIN -password $PASSWORD ; fi 
+CMD if [ $LOGIN = "" ]; then java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT ; else java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT -username $LOGIN -password $PASSWORD ; fi

--- a/3.9.2/english/Dockerfile
+++ b/3.9.2/english/Dockerfile
@@ -30,4 +30,4 @@ ENV LOGIN ""
 ENV PASSWORD ""
 EXPOSE $PORT
 
-CMD if [ $LOGIN = "" ]; then java -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT ; else java -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT -username $LOGIN -password $PASSWORD ; fi 
+CMD if [ $LOGIN = "" ]; then java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT ; else java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT -username $LOGIN -password $PASSWORD ; fi

--- a/3.9.2/french/Dockerfile
+++ b/3.9.2/french/Dockerfile
@@ -30,4 +30,4 @@ ENV LOGIN ""
 ENV PASSWORD ""
 EXPOSE $PORT
 
-CMD if [ $LOGIN = "" ]; then java -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT ; else java -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT -username $LOGIN -password $PASSWORD ; fi 
+CMD if [ $LOGIN = "" ]; then java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT ; else java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT -username $LOGIN -password $PASSWORD ; fi

--- a/3.9.2/german/Dockerfile
+++ b/3.9.2/german/Dockerfile
@@ -30,4 +30,4 @@ ENV LOGIN ""
 ENV PASSWORD ""
 EXPOSE $PORT
 
-CMD if [ $LOGIN = "" ]; then java -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT ; else java -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT -username $LOGIN -password $PASSWORD ; fi 
+CMD if [ $LOGIN = "" ]; then java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT ; else java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT -username $LOGIN -password $PASSWORD ; fi

--- a/3.9.2/spanish/Dockerfile
+++ b/3.9.2/spanish/Dockerfile
@@ -30,4 +30,4 @@ ENV LOGIN ""
 ENV PASSWORD ""
 EXPOSE $PORT
 
-CMD if [ $LOGIN = "" ]; then java -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT ; else java -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT -username $LOGIN -password $PASSWORD ; fi 
+CMD if [ $LOGIN = "" ]; then java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT ; else java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT -username $LOGIN -password $PASSWORD ; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ ENV LOGIN ""
 ENV PASSWORD ""
 EXPOSE $PORT
 
-CMD if [ $LOGIN = "" ]; then java -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT ; else java -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT -username $LOGIN -password $PASSWORD ; fi 
+CMD if [ $LOGIN = "" ]; then java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT ; else java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xmx$JAVA_XMX -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port $PORT -timeout $TIMEOUT -username $LOGIN -password $PASSWORD ; fi


### PR DESCRIPTION
Adds `-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap` to the Java calls.

"As of Java SE 8u131, and in JDK 9, the JVM is Docker-aware with respect to Docker CPU limits transparently. ... For Docker memory limits, there is a little more work for the transparent setting of a maximum Java heap."

See https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits